### PR TITLE
Fix audio recording for cross-platform support (macOS/Windows/Linux)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,13 +60,21 @@ export CONTEXT_WINDOW_LIMIT=10000
 
 For audio recording, optionally set your preferred audio device:
 
-```bash
-export GIA_AUDIO_DEVICE="Headset (WH-1000XM2)"
-```
-
-On Windows:
+**Windows:**
 ```cmd
 set GIA_AUDIO_DEVICE=Headset (WH-1000XM2)
+```
+
+**macOS:**
+```bash
+# Use device index (0, 1, 2, etc.) - run with RUST_LOG=debug to see available devices
+export GIA_AUDIO_DEVICE="0"
+```
+
+**Linux:**
+```bash
+# Use device name or "default"
+export GIA_AUDIO_DEVICE="default"
 ```
 
 GIA will randomly select an API key for each request and automatically fallback to other keys if it encounters a "429 Too Many Requests" error.


### PR DESCRIPTION
Replaced Windows-specific dshow with platform-specific audio backends:
- macOS: AVFoundation with device index format (:N)
- Windows: DirectShow (dshow) with device name format
- Linux: PulseAudio (pulse) with device name format

Fixed audio device detection on macOS to correctly parse AVFoundation output and select audio devices instead of video devices.

Updated README with platform-specific audio device configuration instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)