### PR TITLE
Feat: ✨ Extract TTS speaking logic into a new function

### DIFF
--- a/gia/src/output.rs
+++ b/gia/src/output.rs
@@ -8,7 +8,7 @@ use crate::browser_preview::{open_markdown_preview, FooterMetadata};
 use crate::cli::{Config, ContentSource, OutputMode};
 use crate::clipboard::write_clipboard;
 use crate::conversation::{Conversation, TokenUsage};
-use crate::logging::{log_error, log_info};
+use crate::logging::{log_error, log_info, log_trace};
 
 #[cfg(not(target_os = "macos"))]
 use notify_rust::Notification;
@@ -315,7 +315,7 @@ fn speak_and_wait(text: &str, lang: &str) -> Result<()> {
     log_info("Waiting for speech to complete...");
     // Wait for speech to complete
     while tts.is_speaking()? {
-        log_info("Still speaking...");
+        log_trace("Still speaking...");
         std::thread::sleep(std::time::Duration::from_millis(100));
     }
     log_info("Speech complete");


### PR DESCRIPTION
This commit introduces a new helper function `speak_and_wait` to encapsulate the logic for speaking
text using the Text-to-Speech (TTS) engine and waiting for the speech to complete.

This refactoring addresses the following:

- **Reduces code duplication:** The original implementation repeated the TTS initialization, voice
    setup, speaking, and waiting logic in both `output_text_with_usage` and `speak_conversation`.
    The new function consolidates this into a single, reusable unit.
- **Improves readability and maintainability:** By extracting this common functionality, the main
    functions become cleaner and easier to understand. Any future modifications to the TTS speaking
    behavior can be made in one place.
- **Adds logging for TTS waiting:** The `speak_and_wait` function now includes informative log
    messages to indicate when it's waiting for speech to finish, providing better visibility into
    the program's execution. A small initial delay has also been added to allow the TTS to start
    speaking before entering the waiting loop.
- **Fixes the Issue on Mac (arm)** The thread was checking for `tts.is_speaking` before the tts was started, thus resulting in false and never starting at all.

The `output_text_with_usage` and `speak_conversation` functions now simply call `speak_and_wait`
with the appropriate text and language.