### PR TITLE
local Ollama support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 This is a Cargo workspace containing two binaries:
 
-1. **gia** - Command-line tool that sends prompts to Google's Gemini API and returns AI responses. Supports multiple input sources (command line, clipboard, stdin, files) and output destinations (stdout, clipboard). Supports multimodal interactions with automatic detection of media files (JPEG, PNG, WebP, HEIC, PDF, MP3, MP4, etc.).
+1. **gia** - Command-line tool that sends prompts to Google's Gemini API and returns AI responses. Supports multiple input sources (command line, clipboard, stdin, files) and output destinations (stdout, clipboard). Supports multimodal interactions with automatic detection of media files (JPEG, PNG, WebP, HEIC, PDF, MP3, MP4, etc.). Also supports local Ollama models.
 
 2. **giagui** - GUI wrapper for gia using the egui framework. Must have gia installed and available in PATH.
 
@@ -45,6 +45,9 @@ cargo run -p giagui
 # After building
 ./target/release/gia "your prompt here"
 ./target/release/giagui
+
+# Using Ollama (local, requires Ollama running on localhost:11434)
+cargo run -- -m "ollama::llama3.2" "your prompt here"
 
 # Resume conversations
 cargo run -- --resume "continue previous conversation"
@@ -89,6 +92,8 @@ set GEMINI_API_KEY=your_api_key_here
 set GEMINI_API_KEY=key1|key2|key3
 ```
 
+For Ollama: Install from https://ollama.ai and run `ollama serve`
+
 ### Logging
 ```bash
 RUST_LOG=debug cargo run -- "test"  # Debug logging
@@ -108,7 +113,9 @@ This is a Cargo workspace with shared dependencies and build configuration:
 
 ### Module Structure (gia CLI)
 - `gia/src/main.rs` - CLI argument parsing, main application flow
-- `gia/src/gemini.rs` - Gemini API client with rate limit fallback logic  
+- `gia/src/gemini.rs` - Gemini API client with rate limit fallback logic
+- `gia/src/ollama.rs` - Ollama API client for local LLM support
+- `gia/src/provider.rs` - Provider abstraction and factory
 - `gia/src/api_key.rs` - API key management (multiple keys, validation, fallback)
 - `gia/src/clipboard.rs` - Clipboard operations using arboard
 - `gia/src/conversation.rs` - Conversation management with persistent storage

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -948,7 +948,7 @@ dependencies = [
  "cocoa-foundation",
  "core-foundation 0.9.4",
  "core-graphics",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
  "objc",
 ]
@@ -1064,7 +1064,7 @@ dependencies = [
  "bitflags 1.3.2",
  "core-foundation 0.9.4",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
 ]
 
@@ -1817,12 +1817,21 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared",
+ "foreign-types-shared 0.3.1",
 ]
 
 [[package]]
@@ -1835,6 +1844,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -2062,6 +2077,7 @@ dependencies = [
  "notify-rust",
  "rand 0.8.5",
  "regex",
+ "reqwest",
  "serde",
  "serde_json",
  "serial_test",
@@ -2238,6 +2254,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.11.4",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2375,6 +2410,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -2404,6 +2440,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2422,9 +2474,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -2965,7 +3019,7 @@ dependencies = [
  "bitflags 2.9.4",
  "block",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.5.0",
  "log",
  "objc",
  "paste",
@@ -3057,6 +3111,23 @@ dependencies = [
  "wfd",
  "which",
  "winapi",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -3597,6 +3668,50 @@ checksum = "c7f86c6eef3d6df15f23bcfb6af487cbd2fed4e5581d58d5bf1f5f8b7f6727dc"
 dependencies = [
  "cc",
  "pkg-config",
+]
+
+[[package]]
+name = "openssl"
+version = "0.10.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
+dependencies = [
+ "bitflags 2.9.4",
+ "cfg-if",
+ "foreign-types 0.3.2",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -4219,16 +4334,21 @@ checksum = "d429f34c8092b2d42c7c93cec323bb4adeb7c67698f70839adec842ec10c7ceb"
 dependencies = [
  "base64",
  "bytes",
+ "encoding_rs",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
+ "mime",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -4239,6 +4359,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower",
@@ -4398,6 +4519,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "schemars"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4451,6 +4581,29 @@ name = "sdd"
 version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.9.4",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "serde"
@@ -4857,6 +5010,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags 2.9.4",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5102,6 +5276,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -5470,6 +5654,12 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version-compare"
@@ -6117,6 +6307,17 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad1da3e436dc7653dfdf3da67332e22bff09bb0e28b0239e1624499c7830842e"
+dependencies = [
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]

--- a/gia/Cargo.toml
+++ b/gia/Cargo.toml
@@ -38,5 +38,6 @@ encoding_rs = "0.8"
 chardetng = "0.1"
 tts = "0.26"
 notify-rust = "4.11"
+reqwest = { version = "0.12", features = ["json"] }
 
 

--- a/gia/src/cli.rs
+++ b/gia/src/cli.rs
@@ -194,7 +194,7 @@ impl Config {
                 Arg::new("model")
                     .short('m')
                     .long("model")
-                    .help("Specify the Gemini model to use (see https://ai.google.dev/gemini-api/docs/models)")
+                    .help("Specify the model to use. Format: 'provider::model' (e.g., 'ollama::llama3.2', 'gemini::gemini-2.5-flash-lite'). Default provider is Gemini.")
                     .value_name("MODEL")
                     .default_value("gemini-2.5-flash-lite")
                     .action(clap::ArgAction::Set),

--- a/gia/src/main.rs
+++ b/gia/src/main.rs
@@ -11,6 +11,7 @@ mod gemini;
 mod image;
 mod input;
 mod logging;
+mod ollama;
 mod output;
 mod provider;
 mod role;

--- a/gia/src/ollama.rs
+++ b/gia/src/ollama.rs
@@ -1,0 +1,280 @@
+use crate::conversation::TokenUsage;
+use crate::logging::{log_debug, log_error, log_info, log_trace, log_warn};
+use crate::provider::{AiProvider, AiResponse};
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use genai::chat::{ChatMessage, ChatRole};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize)]
+struct OllamaMessage {
+    role: String,
+    content: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    images: Option<Vec<String>>,
+}
+
+#[derive(Debug, Serialize)]
+struct OllamaChatRequest {
+    model: String,
+    messages: Vec<OllamaMessage>,
+    stream: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct OllamaUsage {
+    #[serde(default)]
+    prompt_tokens: Option<u32>,
+    #[serde(default)]
+    completion_tokens: Option<u32>,
+    #[serde(default)]
+    total_tokens: Option<u32>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OllamaChatResponse {
+    message: OllamaResponseMessage,
+    #[serde(default)]
+    usage: Option<OllamaUsage>,
+    done: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct OllamaResponseMessage {
+    content: String,
+}
+
+#[derive(Debug)]
+pub struct OllamaClient {
+    base_url: String,
+    model: String,
+    client: reqwest::Client,
+}
+
+impl OllamaClient {
+    pub fn new(model: String) -> Result<Self> {
+        let base_url = "http://localhost:11434".to_string();
+
+        log_info(&format!(
+            "Initializing Ollama client with model: {} at {}",
+            model, base_url
+        ));
+
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(300)) // 5 minute timeout for long responses
+            .build()
+            .context("Failed to create HTTP client")?;
+
+        Ok(Self {
+            base_url,
+            model,
+            client,
+        })
+    }
+
+    /// Convert genai ChatMessage to Ollama format
+    fn convert_chat_messages(&self, messages: Vec<ChatMessage>) -> Result<Vec<OllamaMessage>> {
+        let mut ollama_messages = Vec::new();
+
+        for msg in messages {
+            let role = match msg.role {
+                ChatRole::User => "user".to_string(),
+                ChatRole::Assistant => "assistant".to_string(),
+                ChatRole::System => "system".to_string(),
+                ChatRole::Tool => {
+                    log_warn("Tool role not supported by Ollama, converting to user");
+                    "user".to_string()
+                }
+            };
+
+            match msg.content {
+                genai::chat::MessageContent::Text(text) => {
+                    ollama_messages.push(OllamaMessage {
+                        role,
+                        content: text,
+                        images: None,
+                    });
+                }
+                genai::chat::MessageContent::Parts(parts) => {
+                    let mut text_parts = Vec::new();
+                    let mut images = Vec::new();
+
+                    for part in parts {
+                        match part {
+                            genai::chat::ContentPart::Text(text) => {
+                                text_parts.push(text);
+                            }
+                            genai::chat::ContentPart::Image {
+                                content_type,
+                                source,
+                            } => {
+                                if content_type.starts_with("image/") {
+                                    // Extract base64 data from ImageSource
+                                    match source {
+                                        genai::chat::ImageSource::Base64(base64_data) => {
+                                            images.push(base64_data.to_string());
+                                        }
+                                        genai::chat::ImageSource::Url(_url) => {
+                                            log_warn("Image URLs are not yet supported for Ollama conversion");
+                                        }
+                                    }
+                                } else {
+                                    log_warn(&format!(
+                                        "Unsupported inline data type: {}",
+                                        content_type
+                                    ));
+                                }
+                            }
+                        }
+                    }
+
+                    let content = text_parts.join("\n\n");
+                    ollama_messages.push(OllamaMessage {
+                        role,
+                        content,
+                        images: if images.is_empty() {
+                            None
+                        } else {
+                            Some(images)
+                        },
+                    });
+                }
+                _ => {
+                    log_warn(&format!(
+                        "Unsupported message content type: {:?}",
+                        msg.content
+                    ));
+                }
+            }
+        }
+
+        Ok(ollama_messages)
+    }
+
+    async fn send_chat_request(&self, messages: Vec<OllamaMessage>) -> Result<AiResponse> {
+        let endpoint = format!("{}/api/chat", self.base_url);
+
+        let request_body = OllamaChatRequest {
+            model: self.model.clone(),
+            messages,
+            stream: false,
+        };
+
+        log_trace(&format!(
+            "Sending request to Ollama API: {:?}",
+            request_body
+        ));
+
+        let response = self
+            .client
+            .post(&endpoint)
+            .json(&request_body)
+            .send()
+            .await
+            .context("Failed to send request to Ollama API")?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            log_error(&format!("Ollama API error: {} - {}", status, error_text));
+            return Err(anyhow::anyhow!(
+                "Ollama API request failed with status {}: {}",
+                status,
+                error_text
+            ));
+        }
+
+        let chat_response: OllamaChatResponse = response
+            .json()
+            .await
+            .context("Failed to parse Ollama response")?;
+
+        log_trace(&format!(
+            "Received response from Ollama: {:?}",
+            chat_response
+        ));
+
+        if !chat_response.done {
+            log_warn("Received incomplete response from Ollama");
+        }
+
+        let content = chat_response.message.content;
+
+        if content.trim().is_empty() {
+            log_error("Generated text is empty");
+            return Err(anyhow::anyhow!(
+                "No content was generated by the AI. The response was empty or contained only whitespace."
+            ));
+        }
+
+        log_info(&format!(
+            "Received response from Ollama API, length: {}",
+            content.len()
+        ));
+
+        // Extract usage information if available
+        let usage = if let Some(u) = chat_response.usage {
+            TokenUsage {
+                prompt_tokens: u.prompt_tokens,
+                completion_tokens: u.completion_tokens,
+                total_tokens: u.total_tokens,
+            }
+        } else {
+            TokenUsage::default()
+        };
+
+        Ok(AiResponse { content, usage })
+    }
+}
+
+#[async_trait]
+impl AiProvider for OllamaClient {
+    async fn generate_content_with_chat_messages(
+        &mut self,
+        chat_messages: Vec<ChatMessage>,
+    ) -> Result<AiResponse> {
+        log_debug(&format!(
+            "Sending chat request to Ollama API with {} message(s)",
+            chat_messages.len()
+        ));
+
+        let ollama_messages = self
+            .convert_chat_messages(chat_messages)
+            .context("Failed to convert chat messages to Ollama format")?;
+
+        log_info(&format!(
+            "Converted to {} Ollama message(s)",
+            ollama_messages.len()
+        ));
+
+        self.send_chat_request(ollama_messages).await
+    }
+
+    fn model_name(&self) -> &str {
+        &self.model
+    }
+
+    fn provider_name(&self) -> &'static str {
+        "Ollama"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_ollama_client_creation() {
+        let model = "llama3.2".to_string();
+        let client = OllamaClient::new(model.clone());
+        assert!(client.is_ok());
+
+        let client = client.unwrap();
+        assert_eq!(client.model_name(), &model);
+        assert_eq!(client.provider_name(), "Ollama");
+        assert_eq!(client.base_url, "http://localhost:11434");
+    }
+}

--- a/gia/src/provider.rs
+++ b/gia/src/provider.rs
@@ -56,11 +56,15 @@ impl ProviderFactory {
                     crate::gemini::GeminiClient::new(model_name.to_string(), config.api_keys)?;
                 Ok(Box::new(client))
             }
+            "ollama" => {
+                let client = crate::ollama::OllamaClient::new(model_name.to_string())?;
+                Ok(Box::new(client))
+            }
             // Future providers can be added here:
             // "openai" => Ok(Box::new(OpenAiClient::new(model_name.to_string(), config.api_keys)?)),
             // "anthropic" => Ok(Box::new(AnthropicClient::new(model_name.to_string(), config.api_keys)?)),
             _ => Err(anyhow::anyhow!(
-                "Unsupported provider: {provider_name}. Supported providers: gemini"
+                "Unsupported provider: {provider_name}. Supported providers: gemini, ollama"
             )),
         }
     }


### PR DESCRIPTION
Adds support for running local LLMs via 🦙Ollama alongside the existing Gemini provider.

  Features:
  - New 🦙Ollama provider implementation with full multimodal support (text + images)
  - Provider selection using provider::model syntax (e.g., ollama::llama3.2)
  - Defaults to http://localhost:11434 for 🦙Ollama connection
  - Maintains backward compatibility (defaults to Gemini if no provider specified)

  Usage:
  gia -m "ollama::llama3.2" "your prompt"
  gia -m "ollama::llava" "describe this image" -f photo.jpg