### PR TITLE
✨ feat: Remove unused notify_rust import

### DIFF
--- a/gia/src/main.rs
+++ b/gia/src/main.rs
@@ -18,7 +18,6 @@ mod role;
 mod spinner;
 
 use anyhow::Result;
-use notify_rust::Notification;
 
 use crate::app::run_app;
 use crate::cli::Config;


### PR DESCRIPTION
The notify_rust crate was imported but not used in the main.rs file. This commit removes the unused import to clean up the code.